### PR TITLE
LUGG-654 - Add read more settings

### DIFF
--- a/luggage_announcements.info
+++ b/luggage_announcements.info
@@ -59,6 +59,7 @@ features[variable][] = node_preview_announcement
 features[variable][] = node_submitted_announcement
 features[variable][] = pathauto_node_announcement_pattern
 features[variable][] = publishcontent_announcement
+features[variable][] = read_more_announcement_view_modes
 features[variable][] = scheduler_publish_enable_announcement
 features[variable][] = scheduler_publish_past_date_announcement
 features[variable][] = scheduler_unpublish_enable_announcement

--- a/luggage_announcements.strongarm.inc
+++ b/luggage_announcements.strongarm.inc
@@ -118,6 +118,22 @@ function luggage_announcements_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'read_more_announcement_view_modes';
+  $strongarm->value = array(
+    'teaser' => 'teaser',
+    'search_result' => 'search_result',
+    'full' => 0,
+    'rss' => 0,
+    'search_index' => 0,
+    'diff_standard' => 0,
+    'token' => 0,
+    'revision' => 0,
+  );
+  $export['read_more_announcement_view_modes'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'scheduler_publish_enable_announcement';
   $strongarm->value = 1;
   $export['scheduler_publish_enable_announcement'] = $strongarm;


### PR DESCRIPTION
Added strongarm settings for the read more module.

To test:
Pull down these changes on a site with an updated version of the read more module
Run "drush fra -y" on the site you're using for testing
Go to Administration > Configuration > Content Authoring > Read More link
Scroll down to the "Content Types" section of configuration
Verify that teaser and search result highlighting input boxes are both checked for announcement