### PR TITLE
LUGG-770 Fixing luggage_announcements:flexslider_optionset always ovrride

### DIFF
--- a/luggage_announcements.features.field_base.inc
+++ b/luggage_announcements.features.field_base.inc
@@ -10,7 +10,7 @@
 function luggage_announcements_field_default_field_bases() {
   $field_bases = array();
 
-  // Exported field_base: 'field_announcement_alternate_url'
+  // Exported field_base: 'field_announcement_alternate_url'.
   $field_bases['field_announcement_alternate_url'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -39,7 +39,7 @@ function luggage_announcements_field_default_field_bases() {
     'type' => 'link_field',
   );
 
-  // Exported field_base: 'field_announcement_body'
+  // Exported field_base: 'field_announcement_body'.
   $field_bases['field_announcement_body'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -58,7 +58,7 @@ function luggage_announcements_field_default_field_bases() {
     'type' => 'text_with_summary',
   );
 
-  // Exported field_base: 'field_announcement_body_image'
+  // Exported field_base: 'field_announcement_body_image'.
   $field_bases['field_announcement_body_image'] = array(
     'active' => 1,
     'cardinality' => 5,
@@ -80,7 +80,7 @@ function luggage_announcements_field_default_field_bases() {
     'type' => 'image',
   );
 
-  // Exported field_base: 'field_announcement_caption'
+  // Exported field_base: 'field_announcement_caption'.
   $field_bases['field_announcement_caption'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -101,7 +101,7 @@ function luggage_announcements_field_default_field_bases() {
     'type' => 'text',
   );
 
-  // Exported field_base: 'field_announcement_files'
+  // Exported field_base: 'field_announcement_files'.
   $field_bases['field_announcement_files'] = array(
     'active' => 1,
     'cardinality' => -1,
@@ -124,7 +124,7 @@ function luggage_announcements_field_default_field_bases() {
     'type' => 'file',
   );
 
-  // Exported field_base: 'field_announcement_image'
+  // Exported field_base: 'field_announcement_image'.
   $field_bases['field_announcement_image'] = array(
     'active' => 1,
     'cardinality' => 1,
@@ -146,7 +146,7 @@ function luggage_announcements_field_default_field_bases() {
     'type' => 'image',
   );
 
-  // Exported field_base: 'field_announcement_type'
+  // Exported field_base: 'field_announcement_type'.
   $field_bases['field_announcement_type'] = array(
     'active' => 1,
     'cardinality' => -1,

--- a/luggage_announcements.features.field_instance.inc
+++ b/luggage_announcements.features.field_instance.inc
@@ -11,7 +11,7 @@ function luggage_announcements_field_default_field_instances() {
   $field_instances = array();
 
   // Exported field_instance:
-  // 'node-announcement-field_announcement_alternate_url'
+  // 'node-announcement-field_announcement_alternate_url'.
   $field_instances['node-announcement-field_announcement_alternate_url'] = array(
     'bundle' => 'announcement',
     'default_value' => NULL,
@@ -89,7 +89,7 @@ function luggage_announcements_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-announcement-field_announcement_body'
+  // Exported field_instance: 'node-announcement-field_announcement_body'.
   $field_instances['node-announcement-field_announcement_body'] = array(
     'bundle' => 'announcement',
     'default_value' => NULL,
@@ -188,7 +188,7 @@ function luggage_announcements_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-announcement-field_announcement_body_image'
+  // Exported field_instance: 'node-announcement-field_announcement_body_image'.
   $field_instances['node-announcement-field_announcement_body_image'] = array(
     'bundle' => 'announcement',
     'deleted' => 0,
@@ -277,7 +277,7 @@ function luggage_announcements_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-announcement-field_announcement_caption'
+  // Exported field_instance: 'node-announcement-field_announcement_caption'.
   $field_instances['node-announcement-field_announcement_caption'] = array(
     'bundle' => 'announcement',
     'default_value' => NULL,
@@ -335,7 +335,7 @@ function luggage_announcements_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-announcement-field_announcement_files'
+  // Exported field_instance: 'node-announcement-field_announcement_files'.
   $field_instances['node-announcement-field_announcement_files'] = array(
     'bundle' => 'announcement',
     'deleted' => 0,
@@ -416,7 +416,7 @@ function luggage_announcements_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-announcement-field_announcement_image'
+  // Exported field_instance: 'node-announcement-field_announcement_image'.
   $field_instances['node-announcement-field_announcement_image'] = array(
     'bundle' => 'announcement',
     'deleted' => 0,
@@ -505,7 +505,7 @@ function luggage_announcements_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-announcement-field_announcement_type'
+  // Exported field_instance: 'node-announcement-field_announcement_type'.
   $field_instances['node-announcement-field_announcement_type'] = array(
     'bundle' => 'announcement',
     'default_value' => NULL,
@@ -564,7 +564,7 @@ function luggage_announcements_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-announcement-field_category'
+  // Exported field_instance: 'node-announcement-field_category'.
   $field_instances['node-announcement-field_category'] = array(
     'bundle' => 'announcement',
     'default_value' => NULL,
@@ -623,7 +623,7 @@ function luggage_announcements_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-announcement-field_tags'
+  // Exported field_instance: 'node-announcement-field_tags'.
   $field_instances['node-announcement-field_tags'] = array(
     'bundle' => 'announcement',
     'default_value' => NULL,

--- a/luggage_announcements.flexslider_default_preset.inc
+++ b/luggage_announcements.flexslider_default_preset.inc
@@ -16,8 +16,6 @@ function luggage_announcements_flexslider_default_presets() {
   $preset->name = 'announcemant_slider';
   $preset->title = 'announcemant slider';
   $preset->theme = 'classic';
-  $preset->imagestyle_normal = 'announcement_full';
-  $preset->imagestyle_thumbnail = 'flexslider_thumbnail';
   $preset->options = array(
     'namespace' => 'flex-',
     'selector' => '.slides > li',

--- a/luggage_announcements.strongarm.inc
+++ b/luggage_announcements.strongarm.inc
@@ -13,7 +13,7 @@ function luggage_announcements_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
-    $strongarm->name = 'comment_announcement';
+  $strongarm->name = 'comment_announcement';
   $strongarm->value = '1';
   $export['comment_announcement'] = $strongarm;
 


### PR DESCRIPTION
luggage_announcements - It looks like this diff is removing the image styles from the flex slider config and relying on the view configuration to get the correct image style. After re-rolling and confirming the override was fixed, drush fra and checking the slider, it looks fine to me.