### PR TITLE
LUGG-1101 Increase the size of the announcement_full image style

### DIFF
--- a/luggage_announcements.features.field_instance.inc
+++ b/luggage_announcements.features.field_instance.inc
@@ -417,7 +417,7 @@ function luggage_announcements_field_default_field_instances() {
   $field_instances['node-announcement-field_announcement_image'] = array(
     'bundle' => 'announcement',
     'deleted' => 0,
-    'description' => 'This image will be scaled to a width of 1180px, then it will be cropped from the top and bottom equally to 1180px width by 346px height. If you want to control where it will get cropped, please submit an image already resized and cropped to 1180x346.',
+    'description' => 'This image will be scaled to a width of 2000px, then it will be cropped from the top and bottom equally to 2000px width by 604px height. If you want to control where it will get cropped, please submit an image already resized and cropped to 2000x604.',
     'display' => array(
       'default' => array(
         'label' => 'hidden',
@@ -694,7 +694,7 @@ Baseball, bat, glove, ...');
   t('Category');
   t('File(s)');
   t('Tags');
-  t('This image will be scaled to a width of 1180px, then it will be cropped from the top and bottom equally to 1180px width by 346px height. If you want to control where it will get cropped, please submit an image already resized and cropped to 1180x346.');
+  t('This image will be scaled to a width of 2000px, then it will be cropped from the top and bottom equally to 2000px width by 604px height. If you want to control where it will get cropped, please submit an image already resized and cropped to 2000x604.');
 
   return $field_instances;
 }

--- a/luggage_announcements.features.inc
+++ b/luggage_announcements.features.inc
@@ -33,20 +33,20 @@ function luggage_announcements_image_default_styles() {
   $styles['announcement_full'] = array(
     'label' => 'announcement_full',
     'effects' => array(
-      5 => array(
+      1 => array(
         'name' => 'image_scale',
         'data' => array(
-          'width' => 1180,
+          'width' => 2000,
           'height' => '',
-          'upscale' => 0,
+          'upscale' => 1,
         ),
         'weight' => 1,
       ),
-      6 => array(
+      2 => array(
         'name' => 'image_crop',
         'data' => array(
-          'width' => 1180,
-          'height' => 346,
+          'width' => 2000,
+          'height' => 604,
           'anchor' => 'center-center',
         ),
         'weight' => 2,


### PR DESCRIPTION
Increased the image size of announcement banners to 2000x604, making them look better on widescreen and keeping the same proportions. 

To test, 

* Set up an Announcement and upload an image at least 2000x604. Does it resize/crop in a nice way?
* Place the Announcement block in the Hero region. Does the image look pretty good when the screen is about 2000 pix wide? We don't want to go much bigger than that because then load times start to get slow. 
* Does it still look good if the block is in the main content area?